### PR TITLE
#1 Update for Laravel 4.x-5.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
-php: 
-  - 5.3
+php:
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
 
 before_script:
   - curl -s http://getcomposer.org/installer | php

--- a/README.md
+++ b/README.md
@@ -1,29 +1,49 @@
+**README for Laravel 4.x is [here](./README_L4.md)**
+
 # Installation
 
-Update your `composer.json` file to include this package as a dependency
-```json
-"braunson/laravel-rackspace-opencloud": "dev-master"
+Run command in your terminal to include this package as a dependency:
+```bash
+composer require braunson/laravel-rackspace-opencloud
 ```
 
-Register the OpenCloud service provider by adding it to the providers array in your `app/config/app.php` file.
+Register the OpenCloud service provider and alias the OpenCloud facade by adding it to the providers and aliases arrays in the `config/app.php` file.
+
+For Laravel 5.5 and later **don't need** (auto discovery).
+
+For Laravel 5.2 - 5.4:
+
 ```php
 'providers' => [
-	Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider
+    Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider::class
+];
+```
+
+```php
+'aliases' => [
+    'OpenCloud' => Braunson\LaravelRackspaceCdn\Facades\OpenCloud::class
 ]
 ```
 
-Alias the OpenCloud facade by adding it to the aliases array in the `app/config/app.php` file.
+For Laravel 5.1 and earlier:
+
+```php
+'providers' => [
+    'Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider'
+]
+```
+
 ```php
 'aliases' => [
-	'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
+    'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
 ]
 ```
 
 ## Configuration
 
-Copy the config file into your project by running
+Copy the config files into your project by running:
 ```
-php artisan config:publish braunson/laravel-rackspace-opencloud
+php artisan vendor:publish --provider="Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider"
 ```
 
 Edit the config file to include your username, api key, region and url (internal or public).
@@ -34,26 +54,34 @@ Edit the config file to include your username, api key, region and url (internal
 
 Upload files via the command line.
 
-Synchronize a whole directory. Copies all files to /public/assets
+Synchronize a whole directory. Copies all files to `/public/assets`:
 ```
 php artisan cdn:sync public/assets
 ```
 
-Copies all files to /assets trimming 'public' from the path
+Copies all files to `/assets` trimming 'public' from the path:
 ```
 php artisan cdn:sync public/assets --trim=public
+```
+
+You can configure your `package.json` to do this as NPM task:
+
+```json
+"scripts": {
+    "cdn:sync": "php artisan cdn:sync public/assets --trim=public"
+},
 ```
 
 The sync command will save a file adjacent to the synchronized directory. It contains the http and https urls for your container. Along with a md5 hash of the directory.
 In this way when a file changes inside a directory and is reuploaded you get a new cache busted URL.
 
-If you are using the URL helper then it will return a CDN url for a file, if it finds a *.cdn.json file adjacent to one of it's parent directories.
+If you are using the URL helper then it will return a CDN url for a file, if it finds a `*.cdn.json` file adjacent to one of it's parent directories.
 
-```
+```php
 URL::asset('assets/image.jpg');
 ```
 
-You should be able to run `php artisan cdn:sync public/assets --trim=public` before or during a deployment and once complete all files being called by `URL::asset()` will return a CDN resource
+You should be able to run `php artisan cdn:sync public/assets --trim=public` before or during a deployment and once complete all files being called by `URL::asset()` will return a CDN resource.
 
 
 ## Upload to CDN
@@ -62,22 +90,23 @@ You should be able to run `php artisan cdn:sync public/assets --trim=public` bef
 OpenCloud::upload($container, $file, $name = null)
 ```
 
-- $container - (string) Name of the container to upload into
-- $file - (string / UploadedFile) Path to file, or instance of 'Symfony\Component\HttpFoundation\File\UploadedFile' as returned by Input::file()
-- $name - (string) Optional file name to be used when saving the file to the CDN.
+- `$container` - (string) Name of the container to upload into;
+- `$file` - (string / UploadedFile) Path to file, or instance of `Symfony\Component\HttpFoundation\File\UploadedFile` as returned by `Request::file()`;
+- `$name` - (string) Optional file name to be used when saving the file to the CDN.
 
 Example:
 ```php
 Route::post('/upload', function()
-{
-	if(Input::hasFile('image')){
-		$file = OpenCloud::upload('my-container', Input::file('image'));
-	}
+{ 
+    // '\Input' alias was removed from the default aliases in Laravel 5.2+
+    if(Request::hasFile('image')){
+        $file = OpenCloud::upload('my-container', Request::file('image'));
+    }
 
-	$cdnUrl = $file->PublicURL();
-	// Do something with $cdnUrlth
+    $cdnUrl = $file->PublicURL();
+    // Do something with $cdnUrlth
 
-	return Redirect::to('/upload');
+    return Redirect::to('/upload');
 });
 ```
 ## Delete from CDN

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Run command in your terminal to include this package as a dependency:
 composer require braunson/laravel-rackspace-opencloud
 ```
 
-Register the OpenCloud service provider and alias the OpenCloud facade by adding it to the providers and aliases arrays in the `config/app.php` file.
+Register the OpenCloud service provider and alias the OpenCloud, Str (removed in Laravel 5.0+) facades by adding it to the providers and aliases arrays in the `config/app.php` file.
 
 For Laravel 5.5 and later **don't need** (auto discovery).
 
@@ -21,7 +21,8 @@ For Laravel 5.2 - 5.4:
 
 ```php
 'aliases' => [
-    'OpenCloud' => Braunson\LaravelRackspaceCdn\Facades\OpenCloud::class
+    'OpenCloud' => Braunson\LaravelRackspaceCdn\Facades\OpenCloud::class,
+    'Str' => Illuminate\Support\Str::class,
 ]
 ```
 
@@ -35,7 +36,8 @@ For Laravel 5.1 and earlier:
 
 ```php
 'aliases' => [
-    'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
+    'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud',
+    'Str' => 'Illuminate\Support\Str',
 ]
 ```
 

--- a/README_L4.md
+++ b/README_L4.md
@@ -10,7 +10,7 @@ Update your `composer.json` file to include this package as a dependency
 Register the OpenCloud service provider by adding it to the providers array in your `app/config/app.php` file.
 ```php
 'providers' => [
-	Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider
+	'Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider'
 ]
 ```
 

--- a/README_L4.md
+++ b/README_L4.md
@@ -1,0 +1,89 @@
+**README for Laravel 5.x is [here](./README.md)**
+
+# Installation
+
+Update your `composer.json` file to include this package as a dependency
+```json
+"braunson/laravel-rackspace-opencloud": "dev-master"
+```
+
+Register the OpenCloud service provider by adding it to the providers array in your `app/config/app.php` file.
+```php
+'providers' => [
+	Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider
+]
+```
+
+Alias the OpenCloud facade by adding it to the aliases array in the `app/config/app.php` file.
+```php
+'aliases' => [
+	'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
+]
+```
+
+## Configuration
+
+Copy the config file into your project by running
+```
+php artisan config:publish braunson/laravel-rackspace-opencloud
+```
+
+Edit the config file to include your username, api key, region and url (internal or public).
+
+# Usage
+
+## Artisan Commands
+
+Upload files via the command line.
+
+Synchronize a whole directory. Copies all files to /public/assets
+```
+php artisan cdn:sync public/assets
+```
+
+Copies all files to /assets trimming 'public' from the path
+```
+php artisan cdn:sync public/assets --trim=public
+```
+
+The sync command will save a file adjacent to the synchronized directory. It contains the http and https urls for your container. Along with a md5 hash of the directory.
+In this way when a file changes inside a directory and is reuploaded you get a new cache busted URL.
+
+If you are using the URL helper then it will return a CDN url for a file, if it finds a *.cdn.json file adjacent to one of it's parent directories.
+
+```
+URL::asset('assets/image.jpg');
+```
+
+You should be able to run `php artisan cdn:sync public/assets --trim=public` before or during a deployment and once complete all files being called by `URL::asset()` will return a CDN resource
+
+
+## Upload to CDN
+
+```php
+OpenCloud::upload($container, $file, $name = null)
+```
+
+- $container - (string) Name of the container to upload into
+- $file - (string / UploadedFile) Path to file, or instance of 'Symfony\Component\HttpFoundation\File\UploadedFile' as returned by Input::file()
+- $name - (string) Optional file name to be used when saving the file to the CDN.
+
+Example:
+```php
+Route::post('/upload', function()
+{
+	if(Input::hasFile('image')){
+		$file = OpenCloud::upload('my-container', Input::file('image'));
+	}
+
+	$cdnUrl = $file->PublicURL();
+	// Do something with $cdnUrlth
+
+	return Redirect::to('/upload');
+});
+```
+## Delete from CDN
+
+```php
+OpenCloud::delete($container, $file)
+```

--- a/README_L4.md
+++ b/README_L4.md
@@ -2,7 +2,7 @@
 
 # Installation
 
-Update your `composer.json` file to include this package as a dependency
+Update your `composer.json` file to include this package as a dependency:
 ```json
 "braunson/laravel-rackspace-opencloud": "dev-master"
 ```
@@ -10,14 +10,14 @@ Update your `composer.json` file to include this package as a dependency
 Register the OpenCloud service provider by adding it to the providers array in your `app/config/app.php` file.
 ```php
 'providers' => [
-	'Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider'
+    'Braunson\LaravelRackspaceCdn\LaravelRackspaceCdnServiceProvider'
 ]
 ```
 
 Alias the OpenCloud facade by adding it to the aliases array in the `app/config/app.php` file.
 ```php
 'aliases' => [
-	'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
+    'OpenCloud' => 'Braunson\LaravelRackspaceCdn\Facades\OpenCloud'
 ]
 ```
 
@@ -36,12 +36,12 @@ Edit the config file to include your username, api key, region and url (internal
 
 Upload files via the command line.
 
-Synchronize a whole directory. Copies all files to /public/assets
+Synchronize a whole directory. Copies all files to `/public/assets`:
 ```
 php artisan cdn:sync public/assets
 ```
 
-Copies all files to /assets trimming 'public' from the path
+Copies all files to `/assets` trimming 'public' from the path:
 ```
 php artisan cdn:sync public/assets --trim=public
 ```
@@ -49,13 +49,13 @@ php artisan cdn:sync public/assets --trim=public
 The sync command will save a file adjacent to the synchronized directory. It contains the http and https urls for your container. Along with a md5 hash of the directory.
 In this way when a file changes inside a directory and is reuploaded you get a new cache busted URL.
 
-If you are using the URL helper then it will return a CDN url for a file, if it finds a *.cdn.json file adjacent to one of it's parent directories.
+If you are using the URL helper then it will return a CDN url for a file, if it finds a `*.cdn.json` file adjacent to one of it's parent directories.
 
-```
+```php
 URL::asset('assets/image.jpg');
 ```
 
-You should be able to run `php artisan cdn:sync public/assets --trim=public` before or during a deployment and once complete all files being called by `URL::asset()` will return a CDN resource
+You should be able to run `php artisan cdn:sync public/assets --trim=public` before or during a deployment and once complete all files being called by `URL::asset()` will return a CDN resource.
 
 
 ## Upload to CDN
@@ -64,22 +64,22 @@ You should be able to run `php artisan cdn:sync public/assets --trim=public` bef
 OpenCloud::upload($container, $file, $name = null)
 ```
 
-- $container - (string) Name of the container to upload into
-- $file - (string / UploadedFile) Path to file, or instance of 'Symfony\Component\HttpFoundation\File\UploadedFile' as returned by Input::file()
-- $name - (string) Optional file name to be used when saving the file to the CDN.
+- `$container` - (string) Name of the container to upload into;
+- `$file` - (string / UploadedFile) Path to file, or instance of `Symfony\Component\HttpFoundation\File\UploadedFile` as returned by `Input::file()`;
+- `$name` - (string) Optional file name to be used when saving the file to the CDN.
 
 Example:
 ```php
 Route::post('/upload', function()
 {
-	if(Input::hasFile('image')){
-		$file = OpenCloud::upload('my-container', Input::file('image'));
-	}
+    if(Input::hasFile('image')){
+        $file = OpenCloud::upload('my-container', Input::file('image'));
+    }
 
-	$cdnUrl = $file->PublicURL();
-	// Do something with $cdnUrlth
+    $cdnUrl = $file->PublicURL();
+    // Do something with $cdnUrlth
 
-	return Redirect::to('/upload');
+    return Redirect::to('/upload');
 });
 ```
 ## Delete from CDN

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "illuminate/support": "~4.0 || ~5.0",
         "rackspace/php-opencloud": "~1.13.0",
         "alchemy/zippy": "~0.1"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,8 @@
                 "Braunson\\LaravelRackspaceCdn\\LaravelRackspaceCdnServiceProvider"
             ],
             "aliases": {
-                "OpenCloud": "Braunson\\LaravelRackspaceCdn\\Facades\\OpenCloud"
+                "OpenCloud": "Braunson\\LaravelRackspaceCdn\\Facades\\OpenCloud",
+                "Str": "Illuminate\\Support\\Str"
             }
         }
     }

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0", 
-        "illuminate/support": "4.x", 
-        "rackspace/php-opencloud": "1.13.*", 
-        "alchemy/zippy": "0.1.0"
+        "php": ">=5.3.0",
+        "illuminate/support": "~4.0 || ~5.0",
+        "rackspace/php-opencloud": "~1.13.0",
+        "alchemy/zippy": "~0.1"
     },
     "autoload": {
         "classmap": [
             "src/migrations"
-        ], 
+        ],
         "psr-0": {
             "Braunson\\LaravelRackspaceCdn": "src/"
         }
@@ -35,5 +35,5 @@
                 "OpenCloud": "Braunson\\LaravelRackspaceCdn\\Facades\\OpenCloud"
             }
         }
-    } 
+    }
 }

--- a/src/Braunson/LaravelRackspaceCdn/Commands/CdnSyncCommand.php
+++ b/src/Braunson/LaravelRackspaceCdn/Commands/CdnSyncCommand.php
@@ -33,6 +33,19 @@ class CdnSyncCommand extends Command {
 		parent::__construct();
 	}
 
+    /**
+     * Execute the console command (Laravel 5.0+).
+     *
+     * @author Artem Molotov https://github.com/ArtemMolotov
+     * @datetime 12.10.2017 13:10
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->fire();
+    }
+
 	/**
 	 * Execute the console command.
 	 *

--- a/src/Braunson/LaravelRackspaceCdn/Commands/CdnSyncCommand.php
+++ b/src/Braunson/LaravelRackspaceCdn/Commands/CdnSyncCommand.php
@@ -2,6 +2,7 @@
 
 use \File;
 use \Str;
+use Braunson\LaravelRackspaceCdn\ConfigExt;
 
 use Illuminate\Console\Command;
 use Symfony\Component\Console\Input\InputOption;
@@ -54,7 +55,7 @@ class CdnSyncCommand extends Command {
 	public function fire()
     {
         $opencloud = \App::make('open-cloud');
-        $container_name = \Config::get('laravel-rackspace-cdn::container');
+        $container_name = ConfigExt::getFrom('laravel-rackspace-cdn', 'container');
         $container = $opencloud->getContainer($container_name);
 
         // Get directory or file path

--- a/src/Braunson/LaravelRackspaceCdn/ConfigExt.php
+++ b/src/Braunson/LaravelRackspaceCdn/ConfigExt.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @author Artem Molotov https://github.com/ArtemMolotov
+ * @datetime 13.10.2017 20:16
+ */
+
+namespace Braunson\LaravelRackspaceCdn;
+
+use Braunson\LaravelRackspaceCdn\LaravelVersion as Version;
+
+class ConfigExt extends \Config
+{
+
+    /**
+     * Get config value from specified package (Laravel 4.x || 5.x)
+     *
+     * @param string $package
+     * @param string $key
+     * @param mixed $default
+     * @return mixed
+     */
+    public static function getFrom($package, $key, $default = null)
+    {
+        $version = new Version();
+
+        if ($version->compare('5.0', '>=')){
+            return parent::get($package . '.' . $key, $default);
+        } else{
+            return parent::get($package . '::' . $key, $default);
+        }
+
+    }
+
+}

--- a/src/Braunson/LaravelRackspaceCdn/Contracts/OpenCloud.php
+++ b/src/Braunson/LaravelRackspaceCdn/Contracts/OpenCloud.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @author Artem Molotov https://github.com/ArtemMolotov
+ * @datetime 11.10.2017 16:09
+ */
+
+namespace Braunson\LaravelRackspaceCdn\Contracts;
+
+interface OpenCloud
+{
+    /**
+     * Get the object store variable
+     */
+    public function getObjectStore();
+
+    /**
+     * Get/set our container
+     */
+    public function getContainer($name);
+
+    /**
+     * Return objects from the cloud in a specified container
+     */
+    public function getFile($container, $filename);
+
+    /**
+     * Upload files to a set container
+     */
+    public function upload($container, $file, $name = null);
+
+    /**
+     * Create and archive and upload a whole directory
+     *
+     * $dir - Directory to upload
+     * $cdnDir - Directory on the CDN to upload to
+     * $dirTrim - Path segments to trim from the dir path when on the CDN
+     */
+    public function uploadDir($container, $dir, $cdnDir = '', $dirTrim = '');
+
+    public function exists($container, $file);
+
+    public function createDataObject($container, $filePath, $fileName = null, $extract = null);
+
+    public function deleteTEMP($container, $file);
+
+}

--- a/src/Braunson/LaravelRackspaceCdn/Exceptions/CantGetVersionException.php
+++ b/src/Braunson/LaravelRackspaceCdn/Exceptions/CantGetVersionException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @author Artem Molotov https://github.com/ArtemMolotov
+ * @datetime 12.10.2017 14:27
+ */
+
+namespace Braunson\LaravelRackspaceCdn\Exceptions;
+
+use \Exception;
+
+class CantGetVersionException extends Exception
+{
+    protected $message = 'Can\'t get version from object';
+}

--- a/src/Braunson/LaravelRackspaceCdn/Exceptions/IncorrectAppVersionException.php
+++ b/src/Braunson/LaravelRackspaceCdn/Exceptions/IncorrectAppVersionException.php
@@ -1,0 +1,15 @@
+<?php
+
+/**
+ * @author Artem Molotov https://github.com/ArtemMolotov
+ * @datetime 12.10.2017 13:15
+ */
+
+namespace Braunson\LaravelRackspaceCdn\Exceptions;
+
+use \Exception;
+
+class IncorrectAppVersionException extends Exception
+{
+    protected $message = 'Incorrect application version';
+}

--- a/src/Braunson/LaravelRackspaceCdn/LaravelVersion.php
+++ b/src/Braunson/LaravelRackspaceCdn/LaravelVersion.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @author Artem Molotov https://github.com/ArtemMolotov
+ * @datetime 12.10.2017 10:40
+ */
+
+namespace Braunson\LaravelRackspaceCdn;
+
+use Braunson\LaravelRackspaceCdn\Exceptions\CantGetVersionException;
+
+class LaravelVersion
+{
+    /** @var string Laravel version */
+    protected $version;
+
+    /**
+     * LaravelVersion constructor.
+     *
+     * @param \Illuminate\Contracts\Foundation\Application | \Illuminate\Foundation\Application $app
+     * @throws CantGetVersionException
+     */
+    public function __construct($app = null)
+    {
+        if ($app === null) {
+            $app = \App::getFacadeApplication();
+        } elseif (!is_object($app)) {
+            throw new CantGetVersionException();
+        }
+
+        // version() isset in Laravel 5.0+
+        if (method_exists($app, 'version')) {
+            $this->version = $app->version();
+        } elseif (defined(get_class($app) . '::VERSION')) {
+            $this->version = $app::VERSION;
+        } else {
+            throw new CantGetVersionException();
+        }
+    }
+
+    /**
+     * Compare App version with custom version
+     *
+     * @param string $version2
+     * @param string $operator
+     * @return bool
+     */
+    public function compare($version2, $operator = '>=')
+    {
+        return version_compare($this->version, $version2, $operator);
+    }
+}

--- a/src/Braunson/LaravelRackspaceCdn/OpenCloud.php
+++ b/src/Braunson/LaravelRackspaceCdn/OpenCloud.php
@@ -3,6 +3,7 @@
 use \Config;
 use \File;
 use Alchemy\Zippy\Zippy;
+use Braunson\LaravelRackspaceCdn\ConfigExt;
 
 // 5 minutes
 define('RAXSDK_TIMEOUT', 300);
@@ -16,14 +17,16 @@ class OpenCloud extends \OpenCloud\Rackspace {
      */
 	function __construct(){
 
-		$this->region = Config::get('laravel-rackspace-cdn::region');
-        $this->urlType = Config::get('laravel-rackspace-cdn::urlType');
+		$this->region = ConfigExt::getFrom('laravel-rackspace-cdn', 'region');
+        $this->urlType = ConfigExt::getFrom('laravel-rackspace-cdn', 'urlType');
         	
-		$authUrl = ($this->region == 'LON') ? 'https://lon.identity.api.rackspacecloud.com/v2.0/' : 'https://identity.api.rackspacecloud.com/v2.0/';
+		$authUrl = ($this->region == 'LON')
+            ? 'https://lon.identity.api.rackspacecloud.com/v2.0/'
+            : 'https://identity.api.rackspacecloud.com/v2.0/';
 
 		parent::__construct($authUrl, array(
-			'username' => Config::get('laravel-rackspace-cdn::username'),
-			'apiKey' => Config::get('laravel-rackspace-cdn::apiKey')
+			'username' => ConfigExt::getFrom('laravel-rackspace-cdn', 'username'),
+			'apiKey' => ConfigExt::getFrom('laravel-rackspace-cdn', 'apiKey')
 		));
 	}
 


### PR DESCRIPTION
#1 

Hi! I checked every part of the library ([laravel-5](/ArtemMolotov/laravel-rackspace-cdn/tree/laravel-5) branch) as much as possible (Laravel v4.2 and v5.5). It seems that everything works correctly. But... Please, check the code completely. Now when I run any example from README:

```bash
php artisan cdn:sync public/assets --trim=public
```
or
```php
Route::post('/upload', function()
{
    if(\Request::hasFile('image')){
 
        $file = \OpenCloud::upload('my-container', \Request::file('image'));
        $cdnUrl = $file->PublicURL();
        // Do something with $cdnUrlth
    }
});
```
And I see this: 
>  [Guzzle\Http\Exception\ClientErrorResponseException]
>  Client error response
>  [status code] 401
>  [reason phrase] Unauthorized
>  [url] https://identity.api.rackspacecloud.com/v2.0/tokens
